### PR TITLE
Speed up linearization

### DIFF
--- a/src/convexCorridor.jl
+++ b/src/convexCorridor.jl
@@ -10,7 +10,7 @@ Makes an optimal piecewise Linear approximation from x1 to x2 of a convex corrid
 - du : derivative of the upper function
 
 """
-function LinearizeConvex(x1,x2,lower::Function,upper::Function,du::Function)
+function LinearizeConvex(x1,x2,lower,upper,du)
 
     
     tol = 0.00001 

--- a/src/convexCorridor.jl
+++ b/src/convexCorridor.jl
@@ -19,29 +19,28 @@ function LinearizeConvex(x1,x2,lower::Function,upper::Function,du::Function)
     pwl = Array{LinearPiece}(undef, 0)
     
 
-    lin(x) = slope * x + b
     #Δ represent the distance between the linear function and the bottom of the corridor
-    Δ(x) = lin(x) - lower(x)
+    Δ(x, (slope, b)) = slope * x + b - lower(x)
     #distance between the linear function and the bottom of the corridor at the start of the coridor if tangeant in "a"
-    f(a)= upper(a) + du(a)*(x1-a) - lower(x1)
+    f(a,x1) = upper(a) + du(a)*(x1-a) - lower(x1)
 
     while x2 - x1 > tol
 
         #find the tangence point if possible
-        if f(x2) >= 0
+        if f(x2,x1) >= 0
             slope = (upper(x2) - lower(x1)) / (x2 - x1)
             b = lower(x1) - slope * x1
             push!(pwl,LinearPiece(x1,x2,slope,b,ParaToFncLin(slope,b)))
             break
         end
 
-        a = find_zero(f,(x1,x2), Bisection())
+        a = find_zero(Base.Fix2(f, x1),(x1,x2), Bisection())
         slope = du(a)
         b = lower(x1) - slope * x1
 
         #find the second end of the segment
-        if Δ(x2) <= 0
-           nextX1 = find_zero(Δ,(a,x2),Bisection())
+        if Δ(x2, (slope, b)) <= 0
+           nextX1 = find_zero(Base.Fix2(Δ, (slope, b)),(a,x2),Bisection())
         else
             nextX1 = x2
         end

--- a/src/corridorFromInfo.jl
+++ b/src/corridorFromInfo.jl
@@ -34,7 +34,7 @@ end
 Upper(x1::Real,x2::Real,f::Function,df::Function,e::ErrorType,::Under)  = f,df
 Lower(x1::Real,x2::Real,f::Function,e::ErrorType,::Over)  = f
 
-struct Shift{F,T} <: Function
+struct Shift{F,T}
     f::F
     Δ::T
 end
@@ -50,7 +50,7 @@ Upper(x1::Real,x2::Real,f::Function,df::Function,e::ErrorType,::Best) = Upper(x1
 Lower(x1::Real,x2::Real,f::Function,e::Absolute,::Under)  = Shift(f, - e.delta)
 Upper(x1::Real,x2::Real,f::Function,df::Function,e::Absolute,::Over) = Shift(f, + e.delta),df
 
-struct Scale{F,T} <: Function
+struct Scale{F,T}
     f::F
     α::T
 end

--- a/src/exactPiece.jl
+++ b/src/exactPiece.jl
@@ -19,7 +19,7 @@ function ExactPiece(start::Real,maximum::Real,lower,upper)
     epsilon = 1e-5 
     line = LinearPiece(0,0,0,0,x->0)
     pts = collect(range(start,maximum,length=50))
-    data = FctSample.(pts, lower,upper)
+    data = FctSample.(pts, Ref(lower),Ref(upper))
     
     succes=false;
     topIntersec = []
@@ -32,7 +32,7 @@ function ExactPiece(start::Real,maximum::Real,lower,upper)
         while crossing
             
             sort!(pts)
-            data = FctSample.(pts, lower,upper)
+            data = FctSample.(pts, Ref(lower),Ref(upper))
             line = ORourke(data)
 
             #find if the solution on the discretized problem works on the original problem 

--- a/src/strucDef.jl
+++ b/src/strucDef.jl
@@ -108,8 +108,7 @@ FctMaker(e::Expr) = mk_function(:((x -> $e)))
 FctMaker(e::Function) = e
 FctMaker(x::Number) = y->x
 Derive(x::Number) = 0
-Derive(expr::Expr) = Calculus.simplify(differentiate(expr, :x))
-Derive(f::Function) = z->ForwardDiff.gradient(x->f(x[1]),[z])[1]
-#ForwardDiff.derivative(f, x::Real)
+Derive(expr::Expr) = Calculus.simplify(differentiate(expr, :x))  # this is probably super slow
+Derive(f::Function) = Base.Fix1(ForwardDiff.derivative, f)
 
 ;


### PR DESCRIPTION
Hi there @Codsilla and @ngueveu! Following Sandra's awesome presentation at the Julia and Optimization Days, I figured we might be able to gain even more speed compared to the state of the art. Thanks to the tips in my [performance optimization tutorial](https://gdalle.github.io/JuliaOptimizationDays2024-FastJulia/), I achieved the following speed up on a simple test case.

**Current code**

```julia
julia> using BenchmarkTools, LinA

julia> @btime Linearize(abs2, -10, 10, Absolute(0.02));
  4.142 ms (83952 allocations: 1.93 MiB)

julia> @btime Linearize(abs2, -10, 10, Relative(0.02));
  20.275 ms (555988 allocations: 11.34 MiB)
```

**My modifications** (x30 speed up here)

```julia
julia> using BenchmarkTools, LinA

julia> @btime Linearize(abs2, -10, 10, Absolute(0.02));
  129.691 μs (783 allocations: 33.30 KiB)

julia> @btime Linearize(abs2, -10, 10, Relative(0.02));
  543.720 μs (1845 allocations: 99.61 KiB)
```

If you're interested, I can explain to you what I did, and help you improve other aspects of the package.